### PR TITLE
DTMF events should derive from AbstractChannelEvent

### DIFF
--- a/src/Manager/Events/DTMFBeginEvent.cs
+++ b/src/Manager/Events/DTMFBeginEvent.cs
@@ -6,7 +6,7 @@ namespace Sufficit.Asterisk.Manager.Events
     ///     Raised when a DTMF digit has started on a channel.<br/>
     ///     See <see target="_blank"  href="https://wiki.asterisk.org/wiki/display/AST/Asterisk+12+ManagerEvent_DTMFBegin">https://wiki.asterisk.org/wiki/display/AST/Asterisk+12+ManagerEvent_DTMFBegin</see>
     /// </summary>
-    public class DTMFBeginEvent : ManagerEvent
+    public class DTMFBeginEvent : AbstractChannelEvent
     {
         /// <summary>
         /// Gets or sets the direction.

--- a/src/Manager/Events/DTMFEndEvent.cs
+++ b/src/Manager/Events/DTMFEndEvent.cs
@@ -6,7 +6,7 @@ namespace Sufficit.Asterisk.Manager.Events
     ///     Raised when a DTMF digit has ended on a channel.<br/>
     ///     See <see target="_blank"  href="https://wiki.asterisk.org/wiki/display/AST/Asterisk+12+ManagerEvent_DTMFEnd">https://wiki.asterisk.org/wiki/display/AST/Asterisk+12+ManagerEvent_DTMFEnd</see>
     /// </summary>
-    public class DTMFEndEvent : ManagerEvent
+    public class DTMFEndEvent : AbstractChannelInfoEvent
     {
         /// <summary>
         /// Gets or sets the direction.
@@ -22,9 +22,5 @@ namespace Sufficit.Asterisk.Manager.Events
         /// Gets or sets the duration ms.
         /// </summary>
         public int DurationMs { get; set; }
-
-
-
-        //{"channel":"SIP/datora-0000674e","channelstate":"6","channelstatedesc":"Up","calleridnum":"552127672585","calleridname":"552127672585","connectedlinenum":"\u003Cunknown\u003E","connectedlinename":"\u003Cunknown\u003E","language":"pt_BR","context":"ivr-8","exten":"s","priority":"14","uniqueid":"1651500601.160655","linkedid":"1651500601.160655"}
     }
 }


### PR DESCRIPTION
Hello,

DTMFBegin and DTMFEnd based on [documentation](https://docs.asterisk.org/Asterisk_16_Documentation/API_Documentation/AMI_Events/DTMFBegin/) should derive from AbstractChannelEvent

I also removed comment (you can see even in this event data, there are channel attributes).